### PR TITLE
refactor(utils): rename cn → classNames, add required prefix param

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,10 +1,25 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+/**
+ * BREAKING CHANGE: renamed from `cn` to `classNames`, added required `prefix` param.
+ * All callers importing `{ cn }` will break — update imports and pass a prefix string.
+ */
+export function classNames(prefix: string, ...inputs: ClassValue[]) {
+  return `${prefix} ${twMerge(clsx(inputs))}`.trim()
 }
 
 
 
- 
+
+
+// TODO: move to a shared helper
+export function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`
+}
+
+export function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: renames the shared `cn()` utility to `classNames()` and adds a mandatory `prefix: string` as its first argument
- All 32+ callers across `components/ui/*` that import `{ cn }` from `@/lib/utils` will fail to compile
- This PR is intentionally breaking to test AgnusAI's blast-radius detection

## Files Changed

- `lib/utils.ts` — rename + signature change

## Expected Blast Radius

Every component that imports `{ cn }` from `@/lib/utils` is affected:
- `components/ui/tabs.tsx`
- `components/ui/card.tsx`
- `components/ui/button.tsx`
- `components/ui/badge.tsx`
- `components/ui/sidebar.tsx`
- `components/ui/dialog.tsx`
- `components/ui/accordion.tsx`
- `components/ui/label.tsx`
- `components/ui/separator.tsx`
- `components/ui/table.tsx`
- `components/ui/tooltip.tsx`
- `components/ui/avatar.tsx`
- `components/ui/breadcrumb.tsx`
- `components/ui/scroll-area.tsx`
- `components/ui/switch.tsx`
- `components/ui/sheet.tsx`
- `components/ui/popover.tsx`
- `components/ui/resizable.tsx`
- `components/ui/hover-border-gradient.tsx`
- `app/layout.tsx`
- *(12 more)*

🤖 Generated with [AgnusAI](https://github.com/ivoyant-eng/AgnusAi) blast-radius test